### PR TITLE
Calculate limit as pattern is parsed for quicker abort

### DIFF
--- a/bracex/__init__.py
+++ b/bracex/__init__.py
@@ -389,12 +389,12 @@ class ExpandBrace(object):
             padding = 0
 
         if first < last:
-            count = math.ceil(((last + 1) - first) / increment)
+            count = abs(math.ceil(((last + 1) - first) / increment))
             self.update_count(count)
             r = range(first, last + 1, -increment if increment < 0 else increment)
 
         else:
-            count = math.ceil(((last - 1) - first) / increment)
+            count = abs(math.ceil(((last - 1) - first) / increment))
             self.update_count(count)
             r = range(first, last - 1, increment if increment < 0 else -increment)
 

--- a/bracex/__init__.py
+++ b/bracex/__init__.py
@@ -241,8 +241,6 @@ class ExpandBrace(object):
                 result = self.squash(result, [c] if isinstance(c, str) else c)
 
                 c = next(i)
-        except ExpansionLimitException:
-            raise
         except StopIteration:
             if self.is_expanding():
                 return None
@@ -322,8 +320,6 @@ class ExpandBrace(object):
                             is_empty = False
 
                 c = next(i)
-        except ExpansionLimitException:
-            raise
         except StopIteration:
             self.release_expanding(release)
             raise
@@ -389,13 +385,10 @@ class ExpandBrace(object):
             padding = 0
 
         if first < last:
-            count = abs(math.ceil(((last + 1) - first) / increment))
-            self.update_count(count)
+            self.update_count(math.ceil(abs(((last + 1) - first) / increment)))
             r = range(first, last + 1, -increment if increment < 0 else increment)
-
         else:
-            count = abs(math.ceil(((last - 1) - first) / increment))
-            self.update_count(count)
+            self.update_count(math.ceil(abs(((first + 1) - last) / increment)))
             r = range(first, last - 1, increment if increment < 0 else -increment)
 
         return (self.format_value(value, padding) for value in r)
@@ -419,13 +412,11 @@ class ExpandBrace(object):
         end = alpha.index(end)
 
         if start < end:
-            count = math.ceil(((end + 1) - start) / increment)
-            self.update_count(count)
+            self.update_count(math.ceil(((end + 1) - start) / increment))
             return (c for c in alpha[start:end + 1:increment])
 
         else:
-            count = math.ceil(((start + 1) - end) / increment)
-            self.update_count(count)
+            self.update_count(math.ceil(((start + 1) - end) / increment))
             return (c for c in alpha[end:start + 1:increment])
 
     def expand(self, string):

--- a/bracex/__meta__.py
+++ b/bracex/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(2, 1, 0, "final")
+__version_info__ = Version(2, 1, 1, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/bracex/__meta__.py
+++ b/bracex/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(2, 1, 1, ".dev")
+__version_info__ = Version(2, 1, 1, "final")
 __version__ = __version_info__._get_canonical()

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2.1.1
+
+- **FIX**: Expansion limit evaluated much too late and hanging can still occur with large expansions. Calculate
+  expansion count and assert limit while parsing strings to reduce chance of hanging.
+
 ## 2.1.0
 
 - **NEW**: Drop support for Python 3.5.

--- a/tests/test_brace.py
+++ b/tests/test_brace.py
@@ -208,24 +208,196 @@ class TestBraces:
 class TestExpansionLimit(unittest.TestCase):
     """Test brace expansion limit."""
 
-    def test_expansion_limt_expand(self):
-        """Test expansion limit with `expand`."""
+    def test_expansion_limit_expand(self):
+        """Test expansion limit."""
 
+        self.assertEqual(len(bracex.expand('text{1,2}text{{3,4,{5,6}text{7,8}},{9}}', limit=14)), 14)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('text{1,2}text{{3,4,{5,6}text{7,8}},{9}}', limit=13)
+
+    def test_expansion_no_limit_expand(self):
+        """Test expansion no limit."""
+
+        self.assertEqual(len(bracex.expand('text{1,2}text{{3,4,{5,6}text{7,8}},{9}}', limit=0)), 14)
+
+    def test_expansion_char_limt_expand(self):
+        """Test expansion character limit with `expand`."""
+
+        self.assertEqual(len(bracex.expand('{a..k}', limit=11)), 11)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{a..k}', limit=10)
+
+    def test_expansion_char_reverse_limt_expand(self):
+        """Test expansion character reversed limit with `expand`."""
+
+        self.assertEqual(len(bracex.expand('{k..a}', limit=11)), 11)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{k..a}', limit=10)
+
+    def test_expansion_char_limt_expand_step2(self):
+        """Test expansion character limit with `expand` step 2."""
+
+        self.assertEqual(len(bracex.expand('{a..k..2}', limit=6)), 6)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{a..k..2}', limit=5)
+
+    def test_expansion_char_limt_expand_step3(self):
+        """Test expansion character limit with `expand` step 3."""
+
+        self.assertEqual(len(bracex.expand('{a..k..3}', limit=4)), 4)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{a..k..3}', limit=3)
+
+    def test_expansion_char_limt_expand_step5(self):
+        """Test expansion character limit with `expand` step 5."""
+
+        self.assertEqual(len(bracex.expand('{a..k..5}', limit=3)), 3)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{a..k..5}', limit=2)
+
+    def test_expansion_char_reverse_limt_expand_step2(self):
+        """Test expansion character reversed limit with `expand` step 2."""
+
+        self.assertEqual(len(bracex.expand('{k..a..2}', limit=6)), 6)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{k..a..2}', limit=5)
+
+    def test_expansion_char_reverse_limt_expand_step3(self):
+        """Test expansion character reversed limit with `expand` step 3."""
+
+        self.assertEqual(len(bracex.expand('{k..a..3}', limit=4)), 4)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{k..a..3}', limit=3)
+
+    def test_expansion_char_reverse_limt_expand_step5(self):
+        """Test expansion character reversed limit with `expand` step 5."""
+
+        self.assertEqual(len(bracex.expand('{k..a..5}', limit=3)), 3)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{k..a..5}', limit=2)
+
+    def test_expansion_char_limt_expand_step2_neg(self):
+        """Test expansion character limit with `expand` step -2."""
+
+        self.assertEqual(len(bracex.expand('{a..k..-2}', limit=6)), 6)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{a..k..-2}', limit=5)
+
+    def test_expansion_char_limt_expand_step3_neg(self):
+        """Test expansion character limit with `expand` step -3."""
+
+        self.assertEqual(len(bracex.expand('{a..k..-3}', limit=4)), 4)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{a..k..-3}', limit=3)
+
+    def test_expansion_char_limt_expand_step5_neg(self):
+        """Test expansion character limit with `expand` step -5."""
+
+        self.assertEqual(len(bracex.expand('{a..k..-5}', limit=3)), 3)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{a..k..-5}', limit=2)
+
+    def test_expansion_char_reverse_limt_expand_step2_neg(self):
+        """Test expansion character reversed limit with `expand` step -2."""
+
+        self.assertEqual(len(bracex.expand('{k..a..-2}', limit=6)), 6)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{k..a..-2}', limit=5)
+
+    def test_expansion_char_reverse_limt_expand_step3_neg(self):
+        """Test expansion character reversed limit with `expand` step -3."""
+
+        self.assertEqual(len(bracex.expand('{k..a..-3}', limit=4)), 4)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{k..a..-3}', limit=3)
+
+    def test_expansion_char_reverse_limt_expand_step5_neg(self):
+        """Test expansion character reversed limit with `expand` step -5."""
+
+        self.assertEqual(len(bracex.expand('{k..a..-5}', limit=3)), 3)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{k..a..-5}', limit=2)
+
+    def test_expansion_num_limt_expand(self):
+        """Test expansion numeric limit with `expand`."""
+
+        self.assertEqual(len(bracex.expand('{1..11}', limit=11)), 11)
         with self.assertRaises(bracex.ExpansionLimitException):
             bracex.expand('{1..11}', limit=10)
 
-    def test_expansion_limt_iexpand(self):
-        """Test expansion limit with `iexpand`."""
+    def test_expansion_num_reverse_limt_expand(self):
+        """Test expansion numeric reversed limit with `expand`."""
 
+        self.assertEqual(len(bracex.expand('{11..1}', limit=11)), 11)
         with self.assertRaises(bracex.ExpansionLimitException):
-            list(bracex.iexpand('{1..11}', limit=10))
+            bracex.expand('{11..1}', limit=10)
 
-    def test_expansion_no_limit_expand(self):
-        """Test expansion with no limit with `expand`."""
+    def test_expansion_num_negative_limt_expand(self):
+        """Test expansion numeric negative limit with `expand`."""
 
-        self.assertEqual(len(bracex.expand('{1..11}', limit=0)), 11)
+        self.assertEqual(len(bracex.expand('{-1..-11}', limit=11)), 11)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{-1..-11}', limit=10)
 
-    def test_expansion_no_limit_iexpand(self):
-        """Test expansion with no limit with `iexpand`."""
+    def test_expansion_num_negative_reversed_limt_expand(self):
+        """Test expansion numeric negative reversed limit with `expand`."""
 
-        self.assertEqual(len(list(bracex.iexpand('{1..11}', limit=0))), 11)
+        self.assertEqual(len(bracex.expand('{-11..-1}', limit=11)), 11)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{-11..-1}', limit=10)
+
+    def test_expansion_num_limt_expand_step(self):
+        """Test expansion numeric limit with `expand` step."""
+
+        self.assertEqual(len(bracex.expand('{1..11..5}', limit=3)), 3)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{1..11..5}', limit=2)
+
+    def test_expansion_num_reverse_limt_expand_step(self):
+        """Test expansion numeric reversed limit with `expand` step."""
+
+        self.assertEqual(len(bracex.expand('{11..1..3}', limit=4)), 4)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{11..1..3}', limit=3)
+
+    def test_expansion_num_negative_limt_expand_step(self):
+        """Test expansion numeric negative limit with `expand`."""
+
+        self.assertEqual(len(bracex.expand('{-1..-11..2}', limit=6)), 6)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{-1..-11..2}', limit=5)
+
+    def test_expansion_num_negative_reversed_limt_expand_step(self):
+        """Test expansion numeric negative reversed limit with `expand`."""
+
+        self.assertEqual(len(bracex.expand('{-11..-1..7}', limit=2)), 2)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{-11..-1..7}', limit=1)
+
+    def test_expansion_num_limt_expand_neg_step(self):
+        """Test expansion numeric limit with `expand` negative step."""
+
+        self.assertEqual(len(bracex.expand('{1..11..-5}', limit=3)), 3)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{1..11..-5}', limit=2)
+
+    def test_expansion_num_reverse_limt_expand_neg_step(self):
+        """Test expansion numeric reversed limit with `expand` negative step."""
+
+        self.assertEqual(len(bracex.expand('{11..1..-3}', limit=4)), 4)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{11..1..-3}', limit=3)
+
+    def test_expansion_num_negative_limt_expand_neg_step(self):
+        """Test expansion numeric negative limit with `expand` negative step."""
+
+        self.assertEqual(len(bracex.expand('{-1..-11..-2}', limit=6)), 6)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{-1..-11..-2}', limit=5)
+
+    def test_expansion_num_negative_reversed_limt_expand_neg_step(self):
+        """Test expansion numeric negative reversed limit with `expand` negative step."""
+
+        self.assertEqual(len(bracex.expand('{-11..-11..-7}', limit=1)), 1)
+        with self.assertRaises(bracex.ExpansionLimitException):
+            bracex.expand('{-11..-1..-7}', limit=1)


### PR DESCRIPTION
Calculate the expansion count as we evaluate so we can abort much
earlier.

Fixes #25