### PR TITLE
Declare Python 3.10 support. Update CI, version, changelog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       if: "!endsWith(matrix.python-version, '-dev')"
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Set up development Python ${{ matrix.python-version }}
@@ -80,7 +80,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -104,7 +104,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,16 +17,23 @@ jobs:
       max-parallel: 4
       matrix:
         platform: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version:
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
         include:
-          - python-version: 3.6
+          - python-version: "3.6"
             tox-env: py36
-          - python-version: 3.7
+          - python-version: "3.7"
             tox-env: py37
-          - python-version: 3.8
+          - python-version: "3.8"
             tox-env: py38
-          - python-version: 3.9
+          - python-version: "3.9"
             tox-env: py39
+          - python-version: "3.10"
+            tox-env: py310
     env:
       TOXENV: ${{ matrix.tox-env }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.9
       - name: Package

--- a/bracex/__meta__.py
+++ b/bracex/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(2, 1, 1, "final")
+__version_info__ = Version(2, 2, 0, "final")
 __version__ = __version_info__._get_canonical()

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 2.2
+
+- **NEW** Support Python 3.10
+
 ## 2.1.1
 
 - **FIX**: Expansion limit evaluated much too late and hanging can still occur with large expansions. Calculate

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10,'
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -34,4 +34,4 @@ commands=
 [flake8]
 exclude=build/*,.tox/*,bracex/pep562.py
 max-line-length=120
-ignore=D202,D203,D401,N802,N801,N803,N806,E741
+ignore=D202,D203,D401,N802,N801,N803,N806,E741,N818

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 skipsdist=true
 envlist=
     py36,py37,py38,py39,
+    py310,
     lint
 
 [testenv]


### PR DESCRIPTION
Versions in YAML quoted to force parsing as strings. Otherwise 3.10 is parsed as 3.1.

Further reading
- https://dev.to/hugovk/the-python-3-1-problem-85g
- https://yaml-online-parser.appspot.com/?yaml=mangled+version%3A+3.10%0Aright+version%3A+%223.10%22&type=json