### PR TITLE
Add CLI support through `python -mbracex`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ Bracex adds this ability to Python:
 ['file-ad.txt', 'file-bd.txt', 'file-cd.txt']
 ```
 
+and as a command:
+
+```console
+$ python3 -m bracex -0 "base/{a,b}/{1..2}" | xargs -0 mkdir -p
+$ tree base/
+base/
+├── a
+│   ├── 1
+│   └── 2
+└── b
+    ├── 1
+    └── 2
+```
+
 - **Why Bracex over other solutions?**
 
     Bracex actually follows pretty closely to how Bash processes braces. It is not a 1:1 implementation of how Bash
@@ -28,6 +42,8 @@ Bracex adds this ability to Python:
     then our implementation is compared against the results Bash gives. There are a few cases where we have purposely
     deviated. For instance, we are not handling Bash's command line inputs, so we are not giving special meaning to back
     ticks and quotes at this time.
+
+    On the command line Bracex can handle more expansions than Bash itself.
 
 ## Install
 

--- a/bracex/__main__.py
+++ b/bracex/__main__.py
@@ -1,0 +1,66 @@
+"""
+Expands a bash-style brace expression, and outputs each expansion.
+
+Licensed under MIT
+Copyright (c) 2018 - 2020 Isaac Muse <isaacmuse@gmail.com>
+Copyright (c) 2021 Alex Willmer <alex@moreati.org.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+"""
+import argparse
+import bracex
+
+
+def main(argv=None):
+    """Accept command line arguments and output brace expansion to stdout."""
+    parser = argparse.ArgumentParser(
+        prog='python -m bracex',
+        description='Expands a bash-style brace expression, and outputs each expansion.',
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        'expression',
+        help="Brace expression to expand",
+    )
+    terminators = parser.add_mutually_exclusive_group()
+    terminators.add_argument(
+        '--terminator', '-t',
+        default='\n',
+        metavar='STR',
+        help="Terminate each expansion with string STR (default: \\n)",
+    )
+    terminators.add_argument(
+        '-0',
+        action='store_const',
+        const='\0',
+        dest='terminator',
+        help="Terminate each expansion with a NUL character",
+    )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=bracex.__version__,
+    )
+
+    args = parser.parse_args(argv)
+
+    for expansion in bracex.iexpand(args.expression, limit=0):
+        print(expansion, end=args.terminator)
+
+    raise SystemExit(0)
+
+
+if __name__ == '__main__':
+    main()  # pragma: no cover

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -8,12 +8,14 @@ Gitter
 MERCHANTABILITY
 MkDocs
 NONINFRINGEMENT
+NUL
 Preprocess
 PyPI
 TODO
 Tox
 Twemoji
 Virtualenv
+Willmer
 accessor
 deprecations
 expander
@@ -26,6 +28,7 @@ prerelease
 prereleases
 pytest
 regex
+stdout
 sublicense
 tuple
 wordlist

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,7 +2,8 @@
 
 ## 2.2
 
-- **NEW** Support Python 3.10
+- **NEW**: Support Python 3.10
+- **NEW**: Command line interface using `python3 -m bracex`
 
 ## 2.1.1
 

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -17,6 +17,20 @@ Bracex adds this ability to Python:
 ['file-1.txt', 'file-2.txt', 'file-3.txt']
 ```
 
+and as a command:
+
+```shell-session
+$ python3 -m bracex -0 "base/{a,b}/{1..2}" | xargs -0 mkdir -p
+$ tree base/
+base/
+├── a
+│   ├── 1
+│   └── 2
+└── b
+    ├── 1
+    └── 2
+```
+
 - **Why Bracex over other solutions?**
 
     Bracex actually follows pretty closely to how Bash processes braces. It is not a 1:1 implementation of how Bash
@@ -24,6 +38,8 @@ Bracex adds this ability to Python:
     then our implementation is compared against the results Bash gives. There are a few cases where we have purposely
     deviated. For instance, we are not handling Bash's command line inputs, so we are not giving special meaning to back
     ticks and quotes at this time.
+
+    On the command line Bracex can handle more expansions than Bash itself.
 
 More Examples:
 
@@ -115,3 +131,22 @@ def iexpand(string, keep_escapes=False, limit=1000):
 ```
 
 `iexpand` is just like `expand` except it returns a generator.
+
+## Command line interface
+
+```shell-session
+$ python3 -m bracex --help
+usage: python -mbracex [-h] [--terminator STR | -0] [--version] expression
+
+Expands a bash-style brace expression, and outputs each expansion.
+
+positional arguments:
+  expression            Brace expression to expand
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --terminator STR, -t STR
+                        Terminate each expansion with string STR (default: \n)
+  -0                    Terminate each expansion with a NUL character
+  --version             show program's version number and exit
+```

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,95 @@
+"""Test command module and argument handling."""
+import pytest
+from bracex.__main__ import main
+from bracex import __version__
+
+
+def test_expand_with_default_terminator(capsys):
+    """Test that by default one expansion is printed per line."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['{a..c}'])
+    capture = capsys.readouterr()
+    assert capture.out == "a\nb\nc\n"
+    assert capture.err == ""
+    assert exinfo.value.code == 0
+
+
+def test_expand_with_spaces(capsys):
+    """Test that expansions can be space terminated."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['-t', ' ', '{a..c}'])
+    capture = capsys.readouterr()
+    assert capture.out == "a b c "
+    assert capture.err == ""
+    assert exinfo.value.code == 0
+
+
+def test_expand_with_empty_terminators(capsys):
+    """Test that expansions can be terminated by an empty string."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['-t', '', '{a..c}'])
+    capture = capsys.readouterr()
+    assert capture.out == "abc"
+    assert capture.err == ""
+    assert exinfo.value.code == 0
+
+
+def test_expand_with_nul_terminators(capsys):
+    """Test that expansions can be terminated by a NUL character."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['-0', '{a..c}'])
+    capture = capsys.readouterr()
+    assert capture.out == "a\x00b\x00c\x00"
+    assert capture.err == ""
+    assert exinfo.value.code == 0
+
+
+def test_terminator_arguments_are_mutually_exclusive(capsys):
+    """Test that contradicting terminators raise an error."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['-0', '--terminator', ' ', '{a..c}'])
+
+    capture = capsys.readouterr()
+    assert capture.out == ""
+    assert capture.err.find("error: argument --terminator/-t: not allowed with argument -0") > 0
+    assert exinfo.value.code > 0
+
+
+def test_help(capsys):
+    """Test that help is available."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['--help'])
+    capture = capsys.readouterr()
+    assert capture.out.startswith("usage:")
+    assert capture.err == ""
+    assert exinfo.value.code == 0
+
+
+def test_version(capsys):
+    """Test that the version is available."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['--version'])
+    capture = capsys.readouterr()
+    assert capture.out == f"{__version__}\n"
+    assert capture.err == ""
+    assert exinfo.value.code == 0
+
+
+def test_no_args_is_considered_an_error(capsys):
+    """Test that an error is reported when no expression is provided."""
+    with pytest.raises(SystemExit) as exinfo:
+        main([])
+    capture = capsys.readouterr()
+    assert capture.out == ""
+    assert capture.err.endswith("error: the following arguments are required: expression\n")
+    assert exinfo.value.code > 0
+
+
+def test_excess_args_is_considered_an_error(capsys):
+    """Test that an error is reported when too many arguments are provided."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['{a,b,c}', '{1..3}'])
+    capture = capsys.readouterr()
+    assert capture.out == ""
+    assert capture.err.find("error: unrecognized arguments") > 0
+    assert exinfo.value.code > 0


### PR DESCRIPTION
fixes #27

TODO
- [x] Changelog
- [x] Performance test
- [x] Consider parametrised unit tests
- [x] Consider a (default) strict mode (e.g. should an expression with no expansions be considered an error?)