### PR TITLE
fix: char ranges with huge steps must not corrupt

### DIFF
--- a/bracex/__init__.py
+++ b/bracex/__init__.py
@@ -477,10 +477,21 @@ class ExpandBrace:
         last = alpha.index(end)
 
         if first < last:
-            count = math.ceil(((last + 1) - first) / inc)
-            return itertools.islice(alpha, first, last + 1, inc), count
-        count = math.ceil(((first + 1) - last) / inc)
-        return itertools.islice(alpha, last, first + 1, inc), count
+            start_i, stop_i = first, last + 1
+        else:
+            start_i, stop_i = last, first + 1
+
+        span = stop_i - start_i
+        try:
+            count = math.ceil(span / inc)
+        except OverflowError:
+            # Step too large for float division; only the first character is in range.
+            return iter([alpha[start_i]]), 1
+
+        if inc >= span:
+            return iter([alpha[start_i]]), 1
+
+        return itertools.islice(alpha, start_i, stop_i, inc), count
 
     def expand_str(self, string: str) -> Iterator[str]:
         """Expand the string."""

--- a/tests/test_brace.py
+++ b/tests/test_brace.py
@@ -93,7 +93,11 @@ class TestBraces:
         ['1{a..b}2{b..c}3', ['1a2b3', '1a2c3', '1b2b3', '1b2c3']],
         ['{a..b}{b..c}', ['ab', 'ac', 'bb', 'bc']],
         ['{a..k..2}', ['a', 'c', 'e', 'g', 'i', 'k']],
-        ['{b..k..2}', ['b', 'd', 'f', 'h', 'j']]
+        ['{b..k..2}', ['b', 'd', 'f', 'h', 'j']],
+        # Huge steps must expand to the start char (like int ranges), not corrupt.
+        ['{a..z..' + ('9' * 19) + '}', ['a']],
+        ['{z..a..' + ('9' * 19) + '}', ['z']],
+        ['{a..c..' + ('9' * 400) + '}', ['a']],
     ]
 
     error_cases = [


### PR DESCRIPTION
expand/get_char_range hits ValueError when a..z with 19-digit step. This PR fixes the regression with a focused test covering the case.
